### PR TITLE
125 rest service to provide full content of a specified rasa regex (#…

### DIFF
--- a/DSL/Ruuter.private/POST/rasa/regex.yml
+++ b/DSL/Ruuter.private/POST/rasa/regex.yml
@@ -1,0 +1,50 @@
+assign_values:
+  assign:
+    body: ${incoming.body}
+
+extractRequestData:
+  assign:
+    cookie: ${incoming.headers.cookie}
+
+extractTokenData:
+  call: http.post
+  args:
+    # TODO: replace with env variable and correct path to TIM endpoint
+    url: http://localhost:8080/mock-tim-custom-jwt-userinfo
+    headers:
+      cookie: ${cookie}
+    body:
+      # TODO: pass cookie name correctly to TIM
+      cookieName: "customJwtCookie"
+  result: jwtResult
+
+validateAdministrator:
+  switch:
+    # TODO: use correct structure when request is made against TIM
+    - condition: ${jwtResult.response.body.response.authorities.includes("ROLE_ADMINISTRATOR")}
+      next: getRegexes
+  next: returnUnauthorized
+
+getRegexes:
+  call: http.get
+  args:
+    url: http://host.docker.internal:9200/regexes/_search
+  result: getRegexesResult
+
+mapRegexesData:
+  call: http.post
+  args:
+    url: http://host.docker.internal:3000/dmapper/get-regexes
+    body:
+      hits: ${getRegexesResult.response.body.hits.hits}
+      examples: ${body.examples}
+  result: regexesData
+  next: returnSuccess
+
+returnSuccess:
+  return: ${regexesData.response.body}
+  next: end
+
+returnUnauthorized:
+  return: "error: unauthorized"
+  next: end


### PR DESCRIPTION
…154)

* feat: add get all intents

* feat: add POST /rasa/intents endpoint config to ruuter

* feat: opensearch intents field mapping, readme and template update

* feat: add /rasa/intents/examples ruuter config and DMapper config

* feat: add /rasa/intents/examples/count to count examples in intents

* Added get all rules

* Revert "add get all rules"

This reverts commit 7a1e41ab

* 120 Added get all entities

* 127 Added get boolean value if requested entity exists

* Added new lines at the end of files

* 124 Added get all regexes with examples

* 124 Added ruuter regexes.yml file

* 125 Added boolean parameter to check if examples are shown or not

* 125 Added router file

---------