### PR TITLE
Add update delete test stories service (#166)

### DIFF
--- a/DSL/Ruuter.private/GET/return-file-locations.yml
+++ b/DSL/Ruuter.private/GET/return-file-locations.yml
@@ -4,6 +4,7 @@ assign_step:
       rules_location: '/home/raul/buerokratt/Training-Module/mock1/data/rules.yml'
       stories_location: '/home/raul/buerokratt/Training-Module/mock1/data/stories.yml'
       domain_location: '/home/raul/buerokratt/Training-Module/mock1/domain.yml'
+      test_stories_location: '/home/raul/buerokratt/Training-Module/mock1/tests/test_stories.yml'
 
 return_value:
   return: ${locations}

--- a/DSL/Ruuter.private/POST/rasa/rules/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules/add.yml
@@ -3,6 +3,22 @@ assign_values:
     body: ${incoming.body}
     cookie: ${incoming.headers.cookie}
 
+extractTokenData:
+  call: http.post
+  args:
+    url: http://localhost:8080/mock-tim-custom-jwt-userinfo
+    headers:
+      cookie: ${cookie}
+    body:
+      cookieName: "customJwtCookie"
+  result: jwtResult
+
+validateAdministrator:
+  switch:
+    - condition: ${jwtResult.response.body.response.authorities.includes("ROLE_ADMINISTRATOR")}
+      next: getTestStoriesWithName
+  next: returnUnauthorized
+
 getRuleWithName:
   call: http.post
   args:

--- a/DSL/Ruuter.private/POST/rasa/rules/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/rules/update.yml
@@ -3,6 +3,22 @@ assign_values:
     body: ${incoming.body}
     cookie: ${incoming.headers.cookie}
 
+extractTokenData:
+  call: http.post
+  args:
+    url: http://localhost:8080/mock-tim-custom-jwt-userinfo
+    headers:
+      cookie: ${cookie}
+    body:
+      cookieName: "customJwtCookie"
+  result: jwtResult
+
+validateAdministrator:
+  switch:
+    - condition: ${jwtResult.response.body.response.authorities.includes("ROLE_ADMINISTRATOR")}
+      next: getTestStoriesWithName
+  next: returnUnauthorized
+
 getRuleWithName:
   call: http.post
   args:

--- a/DSL/Ruuter.private/POST/rasa/stories/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/add.yml
@@ -3,6 +3,22 @@ assign_values:
     body: ${incoming.body}
     cookie: ${incoming.headers.cookie}
 
+extractTokenData:
+  call: http.post
+  args:
+    url: http://localhost:8080/mock-tim-custom-jwt-userinfo
+    headers:
+      cookie: ${cookie}
+    body:
+      cookieName: "customJwtCookie"
+  result: jwtResult
+
+validateAdministrator:
+  switch:
+    - condition: ${jwtResult.response.body.response.authorities.includes("ROLE_ADMINISTRATOR")}
+      next: getTestStoriesWithName
+  next: returnUnauthorized
+
 getStoriesWithName:
   call: http.post
   args:

--- a/DSL/Ruuter.private/POST/rasa/stories/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/delete.yml
@@ -3,6 +3,22 @@ assign_values:
     story: ${incoming.body.story}
     cookie: ${incoming.headers.cookie}
 
+extractTokenData:
+  call: http.post
+  args:
+    url: http://localhost:8080/mock-tim-custom-jwt-userinfo
+    headers:
+      cookie: ${cookie}
+    body:
+      cookieName: "customJwtCookie"
+  result: jwtResult
+
+validateAdministrator:
+  switch:
+    - condition: ${jwtResult.response.body.response.authorities.includes("ROLE_ADMINISTRATOR")}
+      next: getTestStoriesWithName
+  next: returnUnauthorized
+
 getStoriesWithName:
   call: http.post
   args:
@@ -74,5 +90,5 @@ returnSuccess:
   next: end
 
 returnStoryIsMissing:
-  return: "Can't find rule to delete"
+  return: "Can't find story to delete"
   next: end

--- a/DSL/Ruuter.private/POST/rasa/stories/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/stories/update.yml
@@ -3,6 +3,22 @@ assign_values:
     body: ${incoming.body}
     cookie: ${incoming.headers.cookie}
 
+extractTokenData:
+  call: http.post
+  args:
+    url: http://localhost:8080/mock-tim-custom-jwt-userinfo
+    headers:
+      cookie: ${cookie}
+    body:
+      cookieName: "customJwtCookie"
+  result: jwtResult
+
+validateAdministrator:
+  switch:
+    - condition: ${jwtResult.response.body.response.authorities.includes("ROLE_ADMINISTRATOR")}
+      next: getTestStoriesWithName
+  next: returnUnauthorized
+
 getStoriesWithName:
   call: http.post
   args:
@@ -75,5 +91,5 @@ returnSuccess:
   next: end
 
 returnStoryIsMissing:
-  return: "Can't find rule to update"
+  return: "Can't find story to update"
   next: end

--- a/DSL/Ruuter.private/POST/rasa/test-stories.yml
+++ b/DSL/Ruuter.private/POST/rasa/test-stories.yml
@@ -1,5 +1,6 @@
 extractRequestData:
   assign:
+    params: ${incoming.body}
     cookie: ${incoming.headers.cookie}
 
 extractTokenData:

--- a/DSL/Ruuter.private/POST/rasa/test-stories/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/test-stories/add.yml
@@ -1,6 +1,6 @@
 assign_values:
   assign:
-    rule: ${incoming.body.rule}
+    parameters: ${incoming.body}
     cookie: ${incoming.headers.cookie}
 
 extractTokenData:
@@ -19,21 +19,21 @@ validateAdministrator:
       next: getTestStoriesWithName
   next: returnUnauthorized
 
-getRuleWithName:
+getTestStoriesWithName:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/rules
+    url: http://localhost:8080/rasa/test-stories
     headers:
       cookie: ${cookie}
     body:
-      rule: ${rule}
-  result: ruleResult
+      story: ${parameters.story}
+  result: testStoriesResult
 
-validateRules:
+validateTestStories:
   switch:
-    - condition: ${ruleResult.response.body.response.rule != null}
+    - condition: ${testStoriesResult.response.body.response.stories.length == 0}
       next: getFileLocations
-  next: returnRulesIsMissing
+  next: returnTestStoryExists
 
 getFileLocations:
   call: http.get
@@ -41,54 +41,60 @@ getFileLocations:
     url: http://localhost:8080/return-file-locations
   result: fileLocations
 
-getRulesFile:
+getStoriesFile:
   call: http.post
   args:
     url: http://host.docker.internal:3000/file/read
     body:
-      file_path: ${fileLocations.response.body.response.rules_location}
-  result: ruleFile
+      file_path: ${fileLocations.response.body.response.test_stories_location}
+  result: testStoriesFile
 
 convertYamlToJson:
   call: http.post
   args:
     url: http://host.docker.internal:3000/convert/yaml-to-json
     body:
-      file: ${ruleFile.response.body.file}
-  result: rulesData
+      file: ${testStoriesFile.response.body.file}
+  result: testStoriesData
 
-deleteRule:
+mergeStories:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/delete-rule
+    url: http://host.docker.internal:3000/merge
     body:
-      rules: ${rulesData.response.body.rules}
-      rule_name: ${rule}
-  result: deleteRulesData
+      array1: ${testStoriesData.response.body.stories}
+      array2: ${[parameters]}
+      iteratee: "story"
+  result: mergedTestStories
 
 convertJsonToYaml:
   call: http.post
   args:
     url: http://host.docker.internal:3000/convert/json-to-yaml
     body:
-      version: "3.0"
-      rules: ${deleteRulesData.response.body}
-  result: rulesYaml
+      stories: ${mergedTestStories.response.body}
+  result: testStoriesYaml
 
-saveRulesFile:
+saveFile:
   call: http.post
   args:
     url: http://host.docker.internal:3000/file/write
     body:
-      file_path: ${fileLocations.response.body.response.rules_location}
-      content: ${rulesYaml.response.body.json}
+      file_path: ${fileLocations.response.body.response.test_stories_location}
+      content: ${testStoriesYaml.response.body.json}
   result: fileResult
   next: returnSuccess
 
 returnSuccess:
-  return: "Rule deleted"
+  return: "Test-story added"
   next: end
 
-returnRulesIsMissing:
-  return: "Can't find rule to delete"
+returnTestStoryExists:
+  return: "Test-story exists"
+  status: 409
   next: end
+
+returnUnauthorized:
+  return: "error: unauthorized"
+  next: end
+

--- a/DSL/Ruuter.private/POST/rasa/test-stories/delete.yml
+++ b/DSL/Ruuter.private/POST/rasa/test-stories/delete.yml
@@ -1,6 +1,6 @@
 assign_values:
   assign:
-    rule: ${incoming.body.rule}
+    story: ${incoming.body.story}
     cookie: ${incoming.headers.cookie}
 
 extractTokenData:
@@ -19,21 +19,21 @@ validateAdministrator:
       next: getTestStoriesWithName
   next: returnUnauthorized
 
-getRuleWithName:
+getTestStoriesWithName:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/rules
+    url: http://localhost:8080/rasa/test-stories
     headers:
       cookie: ${cookie}
     body:
-      rule: ${rule}
-  result: ruleResult
+      story: ${story}
+  result: testStoriesResult
 
-validateRules:
+validateTestStories:
   switch:
-    - condition: ${ruleResult.response.body.response.rule != null}
+    - condition: ${testStoriesResult.response.body.response.stories.length != 0}
       next: getFileLocations
-  next: returnRulesIsMissing
+  next: returnTestStoryIsMissing
 
 getFileLocations:
   call: http.get
@@ -41,54 +41,58 @@ getFileLocations:
     url: http://localhost:8080/return-file-locations
   result: fileLocations
 
-getRulesFile:
+getStoriesFile:
   call: http.post
   args:
     url: http://host.docker.internal:3000/file/read
     body:
-      file_path: ${fileLocations.response.body.response.rules_location}
-  result: ruleFile
+      file_path: ${fileLocations.response.body.response.test_stories_location}
+  result: testStoriesFile
 
 convertYamlToJson:
   call: http.post
   args:
     url: http://host.docker.internal:3000/convert/yaml-to-json
     body:
-      file: ${ruleFile.response.body.file}
-  result: rulesData
+      file: ${testStoriesFile.response.body.file}
+  result: testStoriesData
 
-deleteRule:
+deleteTestStory:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/delete-rule
+    url: http://host.docker.internal:3000/dmapper/delete-story
     body:
-      rules: ${rulesData.response.body.rules}
-      rule_name: ${rule}
-  result: deleteRulesData
+      stories: ${testStoriesData.response.body.stories}
+      story_name: ${story}
+  result: deleteTestStoriesData
 
 convertJsonToYaml:
   call: http.post
   args:
     url: http://host.docker.internal:3000/convert/json-to-yaml
     body:
-      version: "3.0"
-      rules: ${deleteRulesData.response.body}
-  result: rulesYaml
+      stories: ${deleteTestStoriesData.response.body}
+  result: testStoriesYaml
 
-saveRulesFile:
+saveFile:
   call: http.post
   args:
     url: http://host.docker.internal:3000/file/write
     body:
-      file_path: ${fileLocations.response.body.response.rules_location}
-      content: ${rulesYaml.response.body.json}
+      file_path: ${fileLocations.response.body.response.test_stories_location}
+      content: ${testStoriesYaml.response.body.json}
   result: fileResult
   next: returnSuccess
 
 returnSuccess:
-  return: "Rule deleted"
+  return: "Test-story deleted"
   next: end
 
-returnRulesIsMissing:
-  return: "Can't find rule to delete"
+returnTestStoryIsMissing:
+  return: "Can't find test-story to delete"
   next: end
+
+returnUnauthorized:
+  return: "error: unauthorized"
+  next: end
+

--- a/DSL/Ruuter.private/POST/rasa/test-stories/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/test-stories/update.yml
@@ -1,6 +1,6 @@
 assign_values:
   assign:
-    rule: ${incoming.body.rule}
+    parameters: ${incoming.body}
     cookie: ${incoming.headers.cookie}
 
 extractTokenData:
@@ -19,21 +19,21 @@ validateAdministrator:
       next: getTestStoriesWithName
   next: returnUnauthorized
 
-getRuleWithName:
+getTestStoriesWithName:
   call: http.post
   args:
-    url: http://localhost:8080/rasa/rules
+    url: http://localhost:8080/rasa/test-stories
     headers:
       cookie: ${cookie}
     body:
-      rule: ${rule}
-  result: ruleResult
+      story: ${parameters.story}
+  result: testStoriesResult
 
-validateRules:
+validateTestStories:
   switch:
-    - condition: ${ruleResult.response.body.response.rule != null}
+    - condition: ${testStoriesResult.response.body.response.stories.length != 0}
       next: getFileLocations
-  next: returnRulesIsMissing
+  next: returnTestStoryIsMissing
 
 getFileLocations:
   call: http.get
@@ -41,54 +41,59 @@ getFileLocations:
     url: http://localhost:8080/return-file-locations
   result: fileLocations
 
-getRulesFile:
+getStoriesFile:
   call: http.post
   args:
     url: http://host.docker.internal:3000/file/read
     body:
-      file_path: ${fileLocations.response.body.response.rules_location}
-  result: ruleFile
+      file_path: ${fileLocations.response.body.response.test_stories_location}
+  result: testStoriesFile
 
 convertYamlToJson:
   call: http.post
   args:
     url: http://host.docker.internal:3000/convert/yaml-to-json
     body:
-      file: ${ruleFile.response.body.file}
-  result: rulesData
+      file: ${testStoriesFile.response.body.file}
+  result: testStoriesData
 
-deleteRule:
+mergeStories:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/delete-rule
+    url: http://host.docker.internal:3000/merge
     body:
-      rules: ${rulesData.response.body.rules}
-      rule_name: ${rule}
-  result: deleteRulesData
+      array1: ${testStoriesData.response.body.stories}
+      array2: ${[parameters]}
+      iteratee: "story"
+  result: mergedTestStories
 
 convertJsonToYaml:
   call: http.post
   args:
     url: http://host.docker.internal:3000/convert/json-to-yaml
     body:
-      version: "3.0"
-      rules: ${deleteRulesData.response.body}
-  result: rulesYaml
+      stories: ${mergedTestStories.response.body}
+  result: testStoriesYaml
 
-saveRulesFile:
+saveFile:
   call: http.post
   args:
     url: http://host.docker.internal:3000/file/write
     body:
-      file_path: ${fileLocations.response.body.response.rules_location}
-      content: ${rulesYaml.response.body.json}
+      file_path: ${fileLocations.response.body.response.test_stories_location}
+      content: ${testStoriesYaml.response.body.json}
   result: fileResult
   next: returnSuccess
 
 returnSuccess:
-  return: "Rule deleted"
+  return: "Test-story updated"
   next: end
 
-returnRulesIsMissing:
-  return: "Can't find rule to delete"
+returnTestStoryIsMissing:
+  return: "Can't find test-story to update"
   next: end
+
+returnUnauthorized:
+  return: "error: unauthorized"
+  next: end
+


### PR DESCRIPTION
* feat: add get all intents

* feat: add POST /rasa/intents endpoint config to ruuter

* feat: opensearch intents field mapping, readme and template update

* feat: add /rasa/intents/examples ruuter config and DMapper config

* feat: add /rasa/intents/examples/count to count examples in intents

* Added get all rules

* Revert "add get all rules"

This reverts commit 7a1e41ab

* feat: add service to add test-stories
feat: add service to update existing test-stories
feat: add service to delete existing test-stories
feat: add test-stories.yml to return-file-locations service
fix: add assign body to test-stories post
fix: add validateRole for rules and stories add, update, delete services
fix: stories error messages

---------