### PR TITLE
93 service to update an existing rasa response (#169)

### DIFF
--- a/DSL/Ruuter.private/POST/rasa/responses/update.yml
+++ b/DSL/Ruuter.private/POST/rasa/responses/update.yml
@@ -1,0 +1,90 @@
+assign_values:
+  assign:
+    parameters: ${incoming.body}
+    cookie: ${incoming.headers.cookie}
+
+extractRequestData:
+  assign:
+    cookie: ${incoming.headers.cookie}
+
+extractTokenData:
+  call: http.post
+  args:
+    url: http://localhost:8080/mock-tim-custom-jwt-userinfo
+    headers:
+      cookie: ${cookie}
+    body:
+      cookieName: "customJwtCookie"
+  result: jwtResult
+
+validateAdministrator:
+  switch:
+    - condition: ${jwtResult.response.body.response.authorities.includes("ROLE_ADMINISTRATOR")}
+      next: getDomainFile
+  next: returnUnauthorized
+
+getDomainFile:
+  call: http.get
+  args:
+    url: http://localhost:8080/domain-file
+    headers:
+      cookie: ${cookie}
+  result: domainData
+
+validateResponse:
+  switch:
+    - condition: ${domainData.response.body.response.responses[parameters.response_name] != null}
+      next: mergeResponses
+  next: returnResponseIsMissing
+
+mergeResponses:
+  call: http.post
+  args:
+    url: http://host.docker.internal:3000/merge/objects
+    body:
+      object1: ${domainData.response.body.response.responses}
+      object2: ${parameters.response}
+  result: mergedResponses
+
+convertJsonToYaml:
+  call: http.post
+  args:
+    url: http://host.docker.internal:3000/convert/json-to-yaml
+    body:
+      version: ${domainData.response.body.response.version}
+      intents: ${domainData.response.body.response.intents}
+      entities: ${domainData.response.body.response.entities}
+      slots: ${domainData.response.body.response.slots}
+      forms: ${domainData.response.body.response.forms}
+      actions: ${domainData.response.body.response.actions}
+      responses: ${mergedResponses.response.body}
+      session_config: ${domainData.response.body.response.session_config}
+  result: domainYaml
+
+getFileLocations:
+  call: http.get
+  args:
+    url: http://localhost:8080/return-file-locations
+  result: fileLocations
+
+saveDomainFile:
+  call: http.post
+  args:
+    url: http://host.docker.internal:3000/file/write
+    body:
+      file_path: ${fileLocations.response.body.response.domain_location}
+      content: ${domainYaml.response.body.json}
+  result: fileResult
+  next: returnSuccess
+
+returnSuccess:
+  return: "Response updated"
+  next: end
+
+returnResponseIsMissing:
+  return: "Can't find response to update"
+  next: end
+
+returnUnauthorized:
+  return: "error: unauthorized"
+  next: end


### PR DESCRIPTION
* feat: add get all intents

* feat: add POST /rasa/intents endpoint config to ruuter

* feat: opensearch intents field mapping, readme and template update

* feat: add /rasa/intents/examples ruuter config and DMapper config

* feat: add /rasa/intents/examples/count to count examples in intents

* Added get all rules

* Revert "add get all rules"

This reverts commit 7a1e41ab

* feat: add service to update existing rasa responses

---------