### PR TITLE
Service to add intent examples (#174)

### DIFF
--- a/DSL/DMapper/get_intent_file.hbs
+++ b/DSL/DMapper/get_intent_file.hbs
@@ -1,0 +1,7 @@
+[
+  {
+    "intent": "{{intent}}",
+    "examples": "{{#each examples}}- {{this}}\n{{/each}}"
+  }
+]
+

--- a/DSL/Node/convert.ts
+++ b/DSL/Node/convert.ts
@@ -38,7 +38,7 @@ router.post('/string/split', multer().array('file'), async (req: Request, res: R
 
 interface ReplaceStringBody {
     data: string;
-    search: RegExp;
+    search: string;
     replace:string;
 }
 router.post('/string/replace', multer().array('file'), async (req: Request, res: Response) => {

--- a/DSL/Node/index.ts
+++ b/DSL/Node/index.ts
@@ -2,6 +2,7 @@ import express, { Express } from 'express';
 import convert from './convert';
 import file from './file';
 import merge from './merge';
+import validate from './validate';
 
 const app: Express = express();
 const port = 3000
@@ -11,6 +12,7 @@ app.use(express.urlencoded());
 app.use('/convert', convert);
 app.use('/file', file);
 app.use('/merge', merge);
+app.use('/validate', validate);
 
 app.listen(port, () => {
     console.log(`[server]: Server is running at http://localhost:${port}`);

--- a/DSL/Node/validate.ts
+++ b/DSL/Node/validate.ts
@@ -1,0 +1,20 @@
+import express, { Router } from 'express';
+const router: Router = express.Router();
+
+interface ArrayElementsLengthBody {
+    array: Array<string>;
+    length: number;
+}
+
+router.post('/array-elements-length', (req, res) => {
+    const { array, length }: ArrayElementsLengthBody = req.body;
+
+    if (!array || !length) {
+        res.status(400).send('Both array and length parameters are required');
+        return;
+    }
+
+    res.json(array.every((value) => value.length <= length));
+});
+
+export default router;

--- a/DSL/Ruuter.private/POST/rasa/intents/examples/add.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/examples/add.yml
@@ -1,0 +1,139 @@
+assign_values:
+  assign:
+    parameters: ${incoming.body}
+    cookie: ${incoming.headers.cookie}
+
+extractRequestData:
+  assign:
+    cookie: ${incoming.headers.cookie}
+
+extractTokenData:
+  call: http.post
+  args:
+    url: http://localhost:8080/mock-tim-custom-jwt-userinfo
+    headers:
+      cookie: ${cookie}
+    body:
+      cookieName: "customJwtCookie"
+  result: jwtResult
+
+validateAdministrator:
+  switch:
+    - condition: ${jwtResult.response.body.response.authorities.includes("ROLE_ADMINISTRATOR")}
+      next: validateArrayExampleLength
+  next: returnUnauthorized
+
+validateArrayExampleLength:
+  call: http.post
+  args:
+    url: http://host.docker.internal:3000/validate/array-elements-length
+    body:
+      array: ${parameters.examples}
+      length: 500
+  result: isValid
+
+validateLength:
+  switch:
+    - condition: ${isValid.response.body}
+      next: getFileLocations
+  next: returnExampleTooLong
+
+getFileLocations:
+  call: http.get
+  args:
+    url: http://localhost:8080/return-file-locations
+  result: fileLocations
+
+getIntentFile:
+  call: http.post
+  args:
+    url: http://host.docker.internal:3000/file/read
+    body:
+      file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + "_nlu.yml"}
+  result: intentFile
+
+convertYamlToJson:
+  call: http.post
+  args:
+    url: http://host.docker.internal:3000/convert/yaml-to-json
+    body:
+      file: ${intentFile.response.body.file}
+  result: intentData
+
+replaceString:
+  call: http.post
+  args:
+    url: http://host.docker.internal:3000/convert/string/replace
+    body:
+      data: ${intentData.response.body.nlu[0].examples}
+      search: "- "
+      replace: ""
+  result: replacedString
+
+splitExamples:
+  call: http.post
+  args:
+    url: http://host.docker.internal:3000/convert/string/split
+    body:
+      data: ${replacedString.response.body}
+      separator: "\n"
+  result: splitExamples
+
+mergeExamples:
+  call: http.post
+  args:
+    url: http://host.docker.internal:3000/merge
+    body:
+      array1: ${parameters.examples}
+      array2: ${splitExamples.response.body}
+  result: mergedExamples
+
+validateMinimumExampleCount:
+  switch:
+    - condition: ${mergedExamples.response.body.length >= 10}
+      next: mapIntentsData
+  next: returnTooFewExamples
+
+mapIntentsData:
+  call: http.post
+  args:
+    url: http://host.docker.internal:3000/dmapper/get-intent-file
+    body:
+      intent: ${parameters.intent}
+      examples: ${mergedExamples.response.body}
+  result: intentFileJson
+
+convertJsonToYaml:
+  call: http.post
+  args:
+    url: http://host.docker.internal:3000/convert/json-to-yaml
+    body:
+      version: "3.0"
+      nlu: ${intentFileJson.response.body}
+  result: intentYaml
+
+saveIntentFile:
+  call: http.post
+  args:
+    url: http://host.docker.internal:3000/file/write
+    body:
+      file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + "_nlu.yml"}
+      content: ${intentYaml.response.body.json}
+  result: fileResult
+  next: returnSuccess
+
+returnSuccess:
+  return: "Examples added"
+  next: end
+
+returnExampleTooLong:
+  return: "Example is too long"
+  next: end
+
+returnTooFewExamples:
+  return: "Too few Examples, add more"
+  next: end
+
+returnUnauthorized:
+  return: "error: unauthorized"
+  next: end


### PR DESCRIPTION
* feat: add get all intents

* feat: add POST /rasa/intents endpoint config to ruuter

* feat: opensearch intents field mapping, readme and template update

* feat: add /rasa/intents/examples ruuter config and DMapper config

* feat: add /rasa/intents/examples/count to count examples in intents

* Added get all rules

* Revert "add get all rules"

This reverts commit 7a1e41ab

* feat: add service to add intent examples
feat: add dataMapper for getting intent nlu
fix: convert string replace service interface

* feat: add service to validate array element length
fix: add validation to add intent example service

* fix: add validate examples count to intent examples add service

---------