### PR TITLE
75 request intent status in model (#184)

### DIFF
--- a/DSL/Ruuter.private/GET/rasa/intents/in-model.yml
+++ b/DSL/Ruuter.private/GET/rasa/intents/in-model.yml
@@ -1,0 +1,35 @@
+extractRequestData:
+  assign:
+    cookie: ${incoming.headers.cookie}
+
+extractTokenData:
+  call: http.post
+  args:
+    url: http://localhost:8080/mock-tim-custom-jwt-userinfo
+    headers:
+      cookie: ${cookie}
+    body:
+      cookieName: "customJwtCookie"
+  result: jwtResult
+
+validateAdministrator:
+  switch:
+    - condition: ${jwtResult.response.body.response.authorities.includes("ROLE_ADMINISTRATOR")}
+      next: getDomainFile
+  next: returnUnauthorized
+
+getDomainFile:
+  call: http.get
+  args:
+    url: http://localhost:8080/domain-file
+    headers:
+      cookie: ${cookie}
+  result: domainData
+
+returnSuccess:
+  return: ${domainData.response.body.response.intents}
+  next: end
+
+returnUnauthorized:
+  return: "error: unauthorized"
+  next: end


### PR DESCRIPTION
* feat: add get all intents

* feat: add POST /rasa/intents endpoint config to ruuter

* feat: opensearch intents field mapping, readme and template update

* feat: add /rasa/intents/examples ruuter config and DMapper config

* feat: add /rasa/intents/examples/count to count examples in intents

* Added get all rules

* Revert "add get all rules"

This reverts commit 7a1e41ab

* feat: add service to get a list of rasa intents that are in domain.yml

---------