### PR TITLE
25 download and upload intents and examples (#185)

### DIFF
--- a/DSL/DMapper/csv_examples_to_array.hbs
+++ b/DSL/DMapper/csv_examples_to_array.hbs
@@ -1,0 +1,5 @@
+[
+  {{#each examples}}
+    {{#each this}}"{{this}}"{{#unless @last}},{{/unless}}{{/each}}{{#unless @last}},{{/unless}}
+  {{/each}}
+]

--- a/DSL/DMapper/get_intent_csv.hbs
+++ b/DSL/DMapper/get_intent_csv.hbs
@@ -1,0 +1,2 @@
+{{#each examples}}"{{this}}"{{#unless @last}}
+{{/unless}}{{/each}}

--- a/DSL/Node/convert.ts
+++ b/DSL/Node/convert.ts
@@ -23,7 +23,7 @@ function base64ToText(base64String: string): string {
 
 router.post('/csv-to-json', multer().array('file'), async (req: Request, res: Response) => {
     const file = base64ToText(req.body.file);
-    let result = Papa.parse(file);
+    let result = Papa.parse(file, {skipEmptyLines: true});
     res.send(result.data);
 });
 interface SplitStringBody {

--- a/DSL/Ruuter.private/POST/rasa/intents/download.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/download.yml
@@ -1,6 +1,6 @@
 assign_values:
   assign:
-    parameters: ${incoming.body}
+    intent: "common_tervitus"
     cookie: ${incoming.headers.cookie}
 
 extractTokenData:
@@ -34,7 +34,7 @@ checkIntentFileYaml:
   args:
     url: http://host.docker.internal:3000/file/check
     body:
-      file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
+      file_path: ${fileLocations.response.body.response.intents_location + intent + file_end}
   result: fileExists
 
 validateFileExists:
@@ -52,7 +52,7 @@ checkIntentFileTmp:
   args:
     url: http://host.docker.internal:3000/file/check
     body:
-      file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
+      file_path: ${fileLocations.response.body.response.intents_location + intent + file_end}
   result: tmpFileExists
 
 validateTmpFileExists:
@@ -66,7 +66,7 @@ getIntentFile:
   args:
     url: http://host.docker.internal:3000/file/read
     body:
-      file_path: ${fileLocations.response.body.response.intents_location + parameters.intent + file_end}
+      file_path: ${fileLocations.response.body.response.intents_location + intent + file_end}
   result: intentFile
 
 convertYamlToJson:
@@ -99,17 +99,25 @@ splitExamples:
 mapIntentsData:
   call: http.post
   args:
-    url: http://host.docker.internal:3000/dmapper/get-intent-examples
+    url: http://host.docker.internal:3000/dmapper/get-intent-csv
+    headers:
+      type: 'csv'
     body:
-      intent: ${parameters.intent}
       examples: ${splitExamples.response.body}
-  result: mappedIntents
+  result: csvData
   next: returnSuccess
 
 returnSuccess:
-  return: ${mappedIntents.response.body}
+  wrapper: false
+  headers:
+    Content-disposition: ${"attachment;filename=" + intent + ".csv"}
+  return: ${csvData.response.body.response}
   next: end
 
 returnUnauthorized:
   return: "error: unauthorized"
+  next: end
+
+returnIntentFileMissing:
+  return: "Intent file to update is missing"
   next: end

--- a/DSL/Ruuter.private/POST/rasa/intents/upload.yml
+++ b/DSL/Ruuter.private/POST/rasa/intents/upload.yml
@@ -1,0 +1,56 @@
+assign_values:
+  assign:
+    parameters: ${incoming.body}
+    cookie: ${incoming.headers.cookie}
+
+extractTokenData:
+  call: http.post
+  args:
+    url: http://localhost:8080/mock-tim-custom-jwt-userinfo
+    headers:
+      cookie: ${cookie}
+    body:
+      cookieName: "customJwtCookie"
+  result: jwtResult
+
+validateAdministrator:
+  switch:
+    - condition: ${jwtResult.response.body.response.authorities.includes("ROLE_ADMINISTRATOR")}
+      next: convertCsvToJson
+  next: returnUnauthorized
+
+convertCsvToJson:
+  call: http.post
+  args:
+    url: http://host.docker.internal:3000/convert/csv-to-json
+    body:
+      file: ${parameters.file}
+  result: jsonData
+
+mapCsvToArray:
+  call: http.post
+  args:
+    url: http://host.docker.internal:3000/dmapper/csv-examples-to-array
+    body:
+      examples: ${jsonData.response.body}
+  result: examples
+
+addExamples:
+  call: http.post
+  args:
+    url: http://localhost:8080/rasa/intents/examples/add
+    headers:
+      cookie: ${cookie}
+    body:
+      intent: ${parameters.intent}
+      examples: ${examples.response.body}
+  result: addResult
+
+returnSuccess:
+  return: ${addResult.response.body.response}
+  next: end
+
+returnUnauthorized:
+  return: "error: unauthorized"
+  next: end
+


### PR DESCRIPTION
* feat: add get all intents

* feat: add POST /rasa/intents endpoint config to ruuter

* feat: opensearch intents field mapping, readme and template update

* feat: add /rasa/intents/examples ruuter config and DMapper config

* feat: add /rasa/intents/examples/count to count examples in intents

* Added get all rules

* Revert "add get all rules"

This reverts commit 7a1e41ab

* feat: add service to download rasa intent examples csv
feat: add service to add rasa intent examples with uploaded csv
fix: rasa intents examples list service to check for .tmp files as well
fix: nodejs service csv-to-json to skip empty lines

---------